### PR TITLE
Fixed bug with AppxOrBundleFile located in the current directory.

### DIFF
--- a/RepackageForWindows10S/MakeAPPXForWin10S.ps1
+++ b/RepackageForWindows10S/MakeAPPXForWin10S.ps1
@@ -90,7 +90,7 @@ function Work($AppxOrBundleFile, $InsideAppx) {
     if ($AppxPathOnly -eq "") # AppxOrBundleFile is located in the current directory
     {
         # AppxPathOnly = current path
-        $AppxPathOnly=Split-Path $MyInvocation.MyCommand.Path
+        $AppxPathOnly=Split-Path $PSScriptPath
     }
     # Does not use an unique folder name. Reusing the same folder in order to allow manual modifications
     #$CurrentDateTime = Get-Date -UFormat "%Y-%m-%d-%Hh-%Mm-%Ss"


### PR DESCRIPTION
$MyInvocation.MyCommand.Path returns null. Changed to use $PSScriptPath.