### PR TITLE
it seems we weren'T done yet. unbundle doesn't support /l. removed.

### DIFF
--- a/RepackageForWindows10S/MakeAPPXForWin10S.ps1
+++ b/RepackageForWindows10S/MakeAPPXForWin10S.ps1
@@ -111,7 +111,7 @@ function Work($AppxOrBundleFile, $InsideAppx) {
     }
     else {
         #BUNDLE
-        & 'C:\Program Files (x86)\Windows Kits\10\App Certification Kit\makeappx.exe' unbundle /p $AppxOrBundleFile /d $UnzippedFolder /l /o
+        & 'C:\Program Files (x86)\Windows Kits\10\App Certification Kit\makeappx.exe' unbundle /p $AppxOrBundleFile /d $UnzippedFolder /o
     }
     Write-Host "Done" -ForegroundColor Yellow
     # =============================================================================


### PR DESCRIPTION
we assumed the /l toggle also exists for unbundle action. however, we were wrong. removed.